### PR TITLE
Incluir parametro de indicacao nos links de agendamento

### DIFF
--- a/app/aulas-coletivas/fitdance/page.tsx
+++ b/app/aulas-coletivas/fitdance/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { Music, Clock, Users, Target, Heart, Zap, Smile } from 'lucide-react'
+import SchedulingLink from '@/components/SchedulingLink'
 
 export const metadata: Metadata = {
   title: 'FitDance | Aulas Coletivas | Academia Panobianco Jardim Satélite',
@@ -302,9 +303,9 @@ export default function FitDancePage() {
               Se você está procurando uma forma divertida e eficaz de se exercitar, o FitDance da Academia Panobianco Jardim Satélite é a sua melhor opção. Venha experimentar a alegria de dançar enquanto cuida da sua saúde e bem-estar.
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Link href="https://agendamento.panobiancosatelite.com.br/" className="bg-white text-red-600 px-8 py-3 rounded-lg font-semibold hover:bg-gray-100 transition-colors" target="_blank" rel="noopener noreferrer">
+              <SchedulingLink className="bg-white text-red-600 px-8 py-3 rounded-lg font-semibold hover:bg-gray-100 transition-colors">
                 Agendar Aula Experimental
-              </Link>
+              </SchedulingLink>
               <Link href="/aulas-coletivas" className="border-2 border-white text-white px-8 py-3 rounded-lg font-semibold hover:bg-white hover:text-red-600 transition-colors">
                 Ver Outras Aulas
               </Link>

--- a/app/aulas-coletivas/flashback/page.tsx
+++ b/app/aulas-coletivas/flashback/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { Music, Clock, Users, Target, Heart, Zap } from 'lucide-react'
+import SchedulingLink from '@/components/SchedulingLink'
 
 export const metadata: Metadata = {
   title: 'Flashback | Aulas Coletivas | Academia Panobianco Jardim Satélite',
@@ -238,9 +239,9 @@ export default function FlashbackPage() {
               Se você está procurando uma forma divertida e eficaz de se exercitar, o Flashback da Academia Panobianco Jardim Satélite é a sua melhor opção. Venha experimentar a alegria de dançar enquanto cuida da sua saúde e bem-estar.
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Link href="https://agendamento.panobiancosatelite.com.br/" className="bg-white text-purple-600 px-8 py-3 rounded-lg font-semibold hover:bg-gray-100 transition-colors" target="_blank" rel="noopener noreferrer">
+              <SchedulingLink className="bg-white text-purple-600 px-8 py-3 rounded-lg font-semibold hover:bg-gray-100 transition-colors">
                 Agendar Aula Experimental
-              </Link>
+              </SchedulingLink>
               <Link href="/aulas-coletivas" className="border-2 border-white text-white px-8 py-3 rounded-lg font-semibold hover:bg-white hover:text-purple-600 transition-colors">
                 Ver Outras Aulas
               </Link>

--- a/app/aulas-coletivas/gap/page.tsx
+++ b/app/aulas-coletivas/gap/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { Target, Clock, Users, Flame, Heart, Shield, Zap } from 'lucide-react'
+import SchedulingLink from '@/components/SchedulingLink'
 
 export const metadata: Metadata = {
   title: 'GAP (Glúteos, Abdômen e Pernas) | Aulas Coletivas | Academia Panobianco Jardim Satélite',
@@ -345,10 +346,10 @@ export default function GAPPage() {
             <p className="text-body mb-8 max-w-2xl mx-auto">
               Se você busca um treino focado e eficaz para glúteos, abdômen e pernas, a aula de GAP da Academia Panobianco Jardim Satélite é a sua melhor opção. Venha sentir a queima, ver a transformação e conquistar o corpo que você sempre desejou.
             </p>
-            <div className="flex flex-col sm:flex-row gap-4 justify-center">
-                              <Link href="https://agendamento.panobiancosatelite.com.br/" className="bg-white text-pink-600 px-8 py-3 rounded-lg font-semibold hover:bg-gray-100 transition-colors" target="_blank" rel="noopener noreferrer">
-                  Agendar Aula Experimental
-                </Link>
+                        <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <SchedulingLink className="bg-white text-pink-600 px-8 py-3 rounded-lg font-semibold hover:bg-gray-100 transition-colors">
+                Agendar Aula Experimental
+              </SchedulingLink>
               <Link href="/aulas-coletivas" className="border-2 border-white text-white px-8 py-3 rounded-lg font-semibold hover:bg-white hover:text-pink-600 transition-colors">
                 Ver Outras Aulas
               </Link>

--- a/app/aulas-coletivas/jiu-jitsu/page.tsx
+++ b/app/aulas-coletivas/jiu-jitsu/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { Shield, Clock, Users, Target, Heart, Brain, Zap } from 'lucide-react'
+import SchedulingLink from '@/components/SchedulingLink'
 
 export const metadata: Metadata = {
   title: 'Jiu Jítsu | Aulas Coletivas | Academia Panobianco Jardim Satélite',
@@ -357,9 +358,9 @@ export default function JiuJitsuPage() {
               Se você busca uma arte marcial que vai além do físico, que desafia sua mente e te ensina a superar limites, o Jiu Jítsu da Academia Panobianco Jardim Satélite é a sua escolha. Venha aprender a arte suave, fortalecer seu corpo e sua mente, e fazer parte de uma comunidade que valoriza a disciplina, o respeito e a evolução constante.
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Link href="https://agendamento.panobiancosatelite.com.br/" className="bg-white text-indigo-600 px-8 py-3 rounded-lg font-semibold hover:bg-gray-100 transition-colors" target="_blank" rel="noopener noreferrer">
+              <SchedulingLink className="bg-white text-indigo-600 px-8 py-3 rounded-lg font-semibold hover:bg-gray-100 transition-colors">
                 Agendar Aula Experimental
-              </Link>
+              </SchedulingLink>
               <Link href="/aulas-coletivas" className="border-2 border-white text-white px-8 py-3 rounded-lg font-semibold hover:bg-white hover:text-indigo-600 transition-colors">
                 Ver Outras Aulas
               </Link>

--- a/app/aulas-coletivas/jump/page.tsx
+++ b/app/aulas-coletivas/jump/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { Activity, Clock, Users, Target, Heart, Zap, Shield } from 'lucide-react'
+import SchedulingLink from '@/components/SchedulingLink'
 
 export const metadata: Metadata = {
   title: 'Jump | Aulas Coletivas | Academia Panobianco Jardim Satélite',
@@ -288,9 +289,9 @@ export default function JumpPage() {
               Se você busca um treino divertido, eficaz e cheio de energia, o Jump da Academia Panobianco Jardim Satélite é a sua próxima parada. Venha sentir a adrenalina, queimar calorias e pular rumo a uma vida mais saudável e ativa.
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Link href="https://agendamento.panobiancosatelite.com.br/" className="bg-white text-green-600 px-8 py-3 rounded-lg font-semibold hover:bg-gray-100 transition-colors" target="_blank" rel="noopener noreferrer">
+              <SchedulingLink className="bg-white text-green-600 px-8 py-3 rounded-lg font-semibold hover:bg-gray-100 transition-colors">
                 Agendar Aula Experimental
-              </Link>
+              </SchedulingLink>
               <Link href="/aulas-coletivas" className="border-2 border-white text-white px-8 py-3 rounded-lg font-semibold hover:bg-white hover:text-green-600 transition-colors">
                 Ver Outras Aulas
               </Link>

--- a/app/aulas-coletivas/muay-thai/page.tsx
+++ b/app/aulas-coletivas/muay-thai/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { Shield, Clock, Users, Target, Heart, Zap, Brain } from 'lucide-react'
+import SchedulingLink from '@/components/SchedulingLink'
 
 export const metadata: Metadata = {
   title: 'Muay Thai | Aulas Coletivas | Academia Panobianco Jardim Satélite',
@@ -335,9 +336,9 @@ export default function MuayThaiPage() {
               Se você busca um treino que vai além do físico, que desafia seus limites e te ensina uma poderosa arte marcial, o Muay Thai da Academia Panobianco Jardim Satélite é a sua escolha. Venha descobrir o guerreiro em você, fortalecer seu corpo e sua mente.
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Link href="https://agendamento.panobiancosatelite.com.br/" className="bg-white text-yellow-600 px-8 py-3 rounded-lg font-semibold hover:bg-gray-100 transition-colors" target="_blank" rel="noopener noreferrer">
+              <SchedulingLink className="bg-white text-yellow-600 px-8 py-3 rounded-lg font-semibold hover:bg-gray-100 transition-colors">
                 Agendar Aula Experimental
-              </Link>
+              </SchedulingLink>
               <Link href="/aulas-coletivas" className="border-2 border-white text-white px-8 py-3 rounded-lg font-semibold hover:bg-white hover:text-yellow-600 transition-colors">
                 Ver Outras Aulas
               </Link>

--- a/app/aulas-coletivas/page.tsx
+++ b/app/aulas-coletivas/page.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react";
 import type { Metadata } from "next";
 import Link from "next/link";
+import SchedulingLink from '@/components/SchedulingLink';
 
 export const metadata: Metadata = {
   title:
@@ -325,14 +326,9 @@ export default function AulasColetivas() {
               aula é gratuita!
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Link
-                href="https://agendamento.panobiancosatelite.com.br/"
-                className="btn-primary"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
+              <SchedulingLink>
                 Experimentar Aula Gratuita
-              </Link>
+              </SchedulingLink>
             </div>
           </div>
         </div>

--- a/app/aulas-coletivas/pilates/page.tsx
+++ b/app/aulas-coletivas/pilates/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { Flower2, Clock, Users, Target, Heart, Shield, Brain } from 'lucide-react'
+import SchedulingLink from '@/components/SchedulingLink'
 
 export const metadata: Metadata = {
   title: 'Pilates | Aulas Coletivas | Academia Panobianco Jardim Satélite',
@@ -280,9 +281,9 @@ export default function PilatesPage() {
               Se você busca uma prática que promove o bem-estar integral, fortalece o corpo e acalma a mente, o Pilates da Academia Panobianco Jardim Satélite é a sua melhor opção. Venha experimentar os benefícios dessa modalidade e descubra uma nova forma de se conectar consigo mesmo.
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Link href="https://agendamento.panobiancosatelite.com.br/" className="bg-white text-blue-600 px-8 py-3 rounded-lg font-semibold hover:bg-gray-100 transition-colors" target="_blank" rel="noopener noreferrer">
+              <SchedulingLink className="bg-white text-blue-600 px-8 py-3 rounded-lg font-semibold hover:bg-gray-100 transition-colors">
                 Agendar Aula Experimental
-              </Link>
+              </SchedulingLink>
               <Link href="/aulas-coletivas" className="border-2 border-white text-white px-8 py-3 rounded-lg font-semibold hover:bg-white hover:text-blue-600 transition-colors">
                 Ver Outras Aulas
               </Link>

--- a/app/aulas-coletivas/wolf-fit/page.tsx
+++ b/app/aulas-coletivas/wolf-fit/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { Zap, Clock, Users, Target, Heart, Activity, Flame } from 'lucide-react'
+import SchedulingLink from '@/components/SchedulingLink'
 
 export const metadata: Metadata = {
   title: 'WolfFit (Ginástica Carioca) | Aulas Coletivas | Academia Panobianco Jardim Satélite',
@@ -274,9 +275,9 @@ export default function WolfFitPage() {
               Se você está procurando uma forma divertida e eficaz de se exercitar, o WolfFit da Academia Panobianco Jardim Satélite é a sua melhor opção. Venha experimentar a alegria de treinar enquanto cuida da sua saúde e bem-estar.
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Link href="https://agendamento.panobiancosatelite.com.br/" className="bg-white text-orange-600 px-8 py-3 rounded-lg font-semibold hover:bg-gray-100 transition-colors" target="_blank" rel="noopener noreferrer">
+              <SchedulingLink className="bg-white text-orange-600 px-8 py-3 rounded-lg font-semibold hover:bg-gray-100 transition-colors">
                 Agendar Aula Experimental
-              </Link>
+              </SchedulingLink>
               <Link href="/aulas-coletivas" className="border-2 border-white text-white px-8 py-3 rounded-lg font-semibold hover:bg-white hover:text-orange-600 transition-colors">
                 Ver Outras Aulas
               </Link>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import Footer from "@/components/Footer";
 import Header from "@/components/Header";
 import { ThemeProvider } from "@/contexts/ThemeContext";
+import { IndicationProvider } from "@/contexts/IndicationContext";
 import type { Metadata } from "next";
 import Script from "next/script";
 import "./globals.css";
@@ -48,9 +49,11 @@ export default function RootLayout({
       </head>
       <body>
         <ThemeProvider>
-          <Header />
-          <main className="min-h-screen">{children}</main>
-          <Footer />
+          <IndicationProvider>
+            <Header />
+            <main className="min-h-screen">{children}</main>
+            <Footer />
+          </IndicationProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { Dumbbell, Users, User, FileCheck, Calendar, MapPin, Clock, Star } from 'lucide-react'
+import SchedulingLink from '@/components/SchedulingLink'
 
 export const metadata: Metadata = {
   title: 'Academia Panobianco Jardim Satélite | Musculação, Aulas Coletivas e Treino Personalizado em São José dos Campos',
@@ -39,14 +40,9 @@ export default function Home() {
               Sua nova jornada de saúde e bem-estar começa aqui. Musculação, aulas coletivas, treino personalizado e muito mais em São José dos Campos.
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Link 
-                href="https://agendamento.panobiancosatelite.com.br/" 
-                className="btn-primary"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
+              <SchedulingLink>
                 Agende sua Aula Experimental
-              </Link>
+              </SchedulingLink>
               <Link href="/planos" className="btn-secondary">
                 Conheça Nossos Planos
               </Link>
@@ -319,15 +315,10 @@ export default function Home() {
               Agende sua aula experimental gratuita e descubra por que a Academia Panobianco Jardim Satélite é o lugar perfeito para você alcançar seus objetivos.
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Link 
-                href="https://agendamento.panobiancosatelite.com.br/" 
-                className="btn-primary"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
+              <SchedulingLink>
                 <Calendar className="h-5 w-5 mr-2" />
                 Agendar Aula Experimental
-              </Link>
+              </SchedulingLink>
               <Link href="/planos" className="btn-secondary">
                 Conheça Nossos Planos
               </Link>

--- a/app/servicos/musculacao/page.tsx
+++ b/app/servicos/musculacao/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { Dumbbell, Target, Shield, TrendingUp, Users, CheckCircle } from 'lucide-react'
+import SchedulingLink from '@/components/SchedulingLink'
 
 export const metadata: Metadata = {
   title: 'Musculação | Academia Panobianco Jardim Satélite - Equipamentos Modernos',
@@ -33,9 +34,9 @@ export default function Musculacao() {
               Nossa área de musculação é um espaço amplo e bem equipado, com uma vasta gama de aparelhos modernos e seguros, projetados para atender a todas as necessidades e grupos musculares.
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Link href="https://agendamento.panobiancosatelite.com.br/" className="btn-primary" target="_blank" rel="noopener noreferrer">
+              <SchedulingLink>
                 Experimente Gratuitamente
-              </Link>
+              </SchedulingLink>
               <Link href="/planos" className="btn-secondary">
                 Conheça Nossos Planos
               </Link>
@@ -253,9 +254,9 @@ export default function Musculacao() {
               Se você busca um lugar onde a musculação é levada a sério, com estrutura de ponta, equipamentos modernos e o suporte de profissionais dedicados, a Academia Panobianco Jardim Satélite é o seu destino.
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Link href="https://agendamento.panobiancosatelite.com.br/" className="btn-primary" target="_blank" rel="noopener noreferrer">
+              <SchedulingLink>
                 Agende Sua Aula Experimental Gratuita
-              </Link>
+              </SchedulingLink>
               <Link href="/contato" className="btn-secondary">
                 Entre em Contato
               </Link>

--- a/app/servicos/page.tsx
+++ b/app/servicos/page.tsx
@@ -1,6 +1,7 @@
 import { Dumbbell, FileCheck, User, Users } from "lucide-react";
 import type { Metadata } from "next";
 import Link from "next/link";
+import SchedulingLink from '@/components/SchedulingLink';
 
 export const metadata: Metadata = {
   title:
@@ -203,14 +204,9 @@ export default function Servicos() {
               e descubra a modalidade que mais te inspira!
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Link
-                href="https://agendamento.panobiancosatelite.com.br/"
-                className="btn-primary"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
+              <SchedulingLink>
                 Aula Experimental Gratuita
-              </Link>
+              </SchedulingLink>
               <Link href="/contato" className="btn-secondary">
                 Entre em Contato
               </Link>

--- a/app/sobre-nos/page.tsx
+++ b/app/sobre-nos/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { Heart, Target, Users, Award, MapPin, Dumbbell } from 'lucide-react'
+import SchedulingLink from '@/components/SchedulingLink'
 
 export const metadata: Metadata = {
   title: 'Sobre Nós | Academia Panobianco Jardim Satélite',
@@ -268,9 +269,9 @@ export default function SobreNos() {
               Venha nos visitar e descubra por que a Academia Panobianco Jardim Satélite é o lugar perfeito para você transformar seu corpo, sua mente e sua vida.
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Link href="https://agendamento.panobiancosatelite.com.br/" className="btn-primary" target="_blank" rel="noopener noreferrer">
+              <SchedulingLink>
                 Agendar Aula Experimental
-              </Link>
+              </SchedulingLink>
               <Link href="/contato" className="btn-secondary">
                 Entre em Contato
               </Link>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,8 +1,13 @@
+"use client";
+
 import { Clock, Facebook, Instagram, MapPin } from "lucide-react";
 import Link from "next/link";
 import Logo from "./Logo";
+import { useIndication } from "@/contexts/IndicationContext";
 
 export default function Footer() {
+  const { getSchedulingUrl } = useIndication();
+  
   return (
     <footer className="bg-secondary border-t border-theme">
       <div className="container-main py-12">
@@ -83,7 +88,7 @@ export default function Footer() {
               </li>
               <li>
                 <Link
-                  href="https://agendamento.panobiancosatelite.com.br/"
+                  href={getSchedulingUrl()}
                   className="text-body text-secondary hover:text-primary-500 transition-colors"
                   target="_blank"
                   rel="noopener noreferrer"

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 
 import ThemeToggle from "./ClientThemeToggle";
 import Logo from "./Logo";
+import { useIndication } from "@/contexts/IndicationContext";
 
 const navigation = [
   { name: "Sobre Nós", href: "/sobre-nos" },
@@ -17,6 +18,7 @@ const navigation = [
 
 export default function Header() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const { getSchedulingUrl } = useIndication();
 
   return (
     <header className="bg-secondary border-b border-theme">
@@ -42,7 +44,7 @@ export default function Header() {
           <div className="hidden md:flex items-center space-x-4">
             <ThemeToggle />
             <Link
-              href="https://agendamento.panobiancosatelite.com.br/"
+              href={getSchedulingUrl()}
               className="btn-primary"
               target="_blank"
               rel="noopener noreferrer"
@@ -84,7 +86,7 @@ export default function Header() {
               ))}
               <div className="px-4 py-2">
                 <Link
-                  href="https://agendamento.panobiancosatelite.com.br/"
+                  href={getSchedulingUrl()}
                   className="btn-primary w-full text-center"
                   onClick={() => setMobileMenuOpen(false)}
                   target="_blank"

--- a/components/SchedulingLink.tsx
+++ b/components/SchedulingLink.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import Link from "next/link";
+import { useIndication } from "@/contexts/IndicationContext";
+
+interface SchedulingLinkProps {
+  children: React.ReactNode;
+  className?: string;
+  baseUrl?: string;
+}
+
+export default function SchedulingLink({ 
+  children, 
+  className = "btn-primary", 
+  baseUrl 
+}: SchedulingLinkProps) {
+  const { getSchedulingUrl } = useIndication();
+
+  return (
+    <Link
+      href={getSchedulingUrl(baseUrl)}
+      className={className}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      {children}
+    </Link>
+  );
+}

--- a/contexts/IndicationContext.tsx
+++ b/contexts/IndicationContext.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+
+interface IndicationContextType {
+  indication: string | null;
+  getSchedulingUrl: (baseUrl?: string) => string;
+}
+
+const IndicationContext = createContext<IndicationContextType | undefined>(undefined);
+
+interface IndicationProviderProps {
+  children: ReactNode;
+}
+
+export function IndicationProvider({ children }: IndicationProviderProps) {
+  const [indication, setIndication] = useState<string | null>(null);
+
+  useEffect(() => {
+    // Capturar o parâmetro de indicação da URL quando o componente montar
+    if (typeof window !== 'undefined') {
+      const urlParams = new URLSearchParams(window.location.search);
+      const indicationParam = urlParams.get('indicacao');
+      if (indicationParam) {
+        setIndication(indicationParam);
+        // Armazenar no sessionStorage para persistir durante a sessão
+        sessionStorage.setItem('indication', indicationParam);
+      } else {
+        // Verificar se existe no sessionStorage
+        const storedIndication = sessionStorage.getItem('indication');
+        if (storedIndication) {
+          setIndication(storedIndication);
+        }
+      }
+    }
+  }, []);
+
+  const getSchedulingUrl = (baseUrl: string = 'https://agendamento.panobiancosatelite.com.br/') => {
+    if (!indication) {
+      return baseUrl;
+    }
+    
+    const url = new URL(baseUrl);
+    url.searchParams.set('indicacao', indication);
+    return url.toString();
+  };
+
+  return (
+    <IndicationContext.Provider value={{ indication, getSchedulingUrl }}>
+      {children}
+    </IndicationContext.Provider>
+  );
+}
+
+export function useIndication() {
+  const context = useContext(IndicationContext);
+  if (context === undefined) {
+    throw new Error('useIndication must be used within an IndicationProvider');
+  }
+  return context;
+}


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add support for the `?indicacao=XXX` URL parameter to automatically include it in all scheduling links.

---
<a href="https://cursor.com/background-agent?bcId=bc-e5a4b422-c679-495d-8b02-22ce045f3800">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e5a4b422-c679-495d-8b02-22ce045f3800">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>